### PR TITLE
Update brand config to match what console is currently using

### DIFF
--- a/manifests/0000_10_origin-branding_configmap.yaml
+++ b/manifests/0000_10_origin-branding_configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   console-config.yaml: |
     kind: ConsoleConfig
-    apiVersion: console.openshift.io/v1beta1
+    apiVersion: console.openshift.io/v1
     customization:
       branding: okd
       documentationBaseURL: https://docs.okd.io/4.0/

--- a/manifests/0000_10_origin-branding_configmap.yaml
+++ b/manifests/0000_10_origin-branding_configmap.yaml
@@ -6,9 +6,8 @@ metadata:
   namespace: openshift-config-managed
 data:
   console-config.yaml: |
-    kind: Console
-    apiVersion: config.openshift.io/v1
-    spec:
-      customization:
-        branding: okd
-        documentationBaseURL: https://docs.okd.io/4.0/
+    kind: ConsoleConfig
+    apiVersion: console.openshift.io/v1beta1
+    customization:
+      branding: okd
+      documentationBaseURL: https://docs.okd.io/4.0/


### PR DESCRIPTION
This file is suppose to merge with the current console config to set the brand as okd.  However, the original version did not align with what we currently use in the console.