### PR TITLE
branding: fix object in embedded file within configmap

### DIFF
--- a/manifests/0000_10_origin-branding_configmap.yaml
+++ b/manifests/0000_10_origin-branding_configmap.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: openshift-config-managed
 data:
   console-config.yaml: |
-    kind: ConsoleConfig
-    apiVersion: console.openshift.io/v1
+    kind: Console
+    apiVersion: config.openshift.io/v1
     customization:
       branding: okd
       documentationBaseURL: https://docs.okd.io/4.0/


### PR DESCRIPTION
The console object really resides in the config.openshift.io namespace with the Console object.

@sjenning @smarterclayton @enj @sallyom 

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1700891
Ref: https://github.com/openshift/cluster-authentication-operator/pull/119