### PR TITLE
Bug 1932488: Add CVO cluster-profile annotations

### DIFF
--- a/manifests/0000_10_origin-branding_configmap.yaml
+++ b/manifests/0000_10_origin-branding_configmap.yaml
@@ -2,6 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: console-config
   namespace: openshift-config-managed
 data:


### PR DESCRIPTION
Include the annotation so that CVO would pick this manifest when cluster-profile is selected.

Cherry-pick of # on release-4.7