### PR TITLE
Bug 1927993: Fix documentation link for OKD

### DIFF
--- a/manifests/0000_10_origin-branding_configmap.yaml
+++ b/manifests/0000_10_origin-branding_configmap.yaml
@@ -13,4 +13,4 @@ data:
     apiVersion: console.openshift.io/v1
     customization:
       branding: okd
-      documentationBaseURL: https://docs.okd.io/4.0/
+      documentationBaseURL: https://docs.okd.io/latest/


### PR DESCRIPTION
wondering if for backport we wanna set a matching version or just point to latest?

/assign @spadgett 